### PR TITLE
Standardize import setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,20 @@ class MyFramework(EvaluativeFrameworkBase):
 
 MyFramework().evaluate("This is a symbolic test line.")
 
+## Import Policy
+
+All modules use absolute imports from the repository root (for example
+`from cortex.frameworks.engine import ReflectiveFrameworkBase`). Scripts and
+tests add the repository root to `sys.path` using
+`sos_path.add_repo_root_to_path()`. When working in a parallel directory such as
+`local/`, import this helper before other project modules:
+
+```python
+from sos_path import add_repo_root_to_path
+add_repo_root_to_path()
+```
+
+This ensures your local scripts resolve the same packages as the main project.
 
 License
 

--- a/conftest.py
+++ b/conftest.py
@@ -1,6 +1,7 @@
 # conftest.py
-import sys
-import os
+"""Pytest configuration for SymbolicOperatingSystem."""
 
-# Ensure the repo root is on sys.path so top-level packages (frameworks/) resolve.
-sys.path.insert(0, os.path.abspath(os.path.dirname(__file__)))
+from sos_path import add_repo_root_to_path
+
+# Ensure tests use the repository root for imports
+add_repo_root_to_path()

--- a/cortex/frameworks/SymbolicEcho.py
+++ b/cortex/frameworks/SymbolicEcho.py
@@ -1,0 +1,18 @@
+class SymbolicEcho:
+    """Simple echo object used by ReflectiveFrameworkBase."""
+
+    def __init__(self, event=None, z_trace=None, weight=1.0, foundational=False):
+        self.event = event
+        self.z_trace = z_trace or []
+        self.weight = weight
+        self.foundational = foundational
+
+    def process(self, unit):
+        """Return a basic analysis structure."""
+        return {
+            "input": unit,
+            "weight": self.weight,
+            "foundational": self.foundational,
+            "trace": list(self.z_trace),
+        }
+

--- a/cortex/frameworks/engine/EvaluativeFrameworkBase.py
+++ b/cortex/frameworks/engine/EvaluativeFrameworkBase.py
@@ -1,7 +1,7 @@
 
 # File: cortex/frameworks/engine/EvaluativeFrameworkBase.py
 
-from ReflectiveFrameworkBase import ReflectiveFrameworkBase
+from .ReflectiveFrameworkBase import ReflectiveFrameworkBase
 
 class EvaluativeFrameworkBase(ReflectiveFrameworkBase):
     '''

--- a/frameworks/compression.py
+++ b/frameworks/compression.py
@@ -5,7 +5,7 @@ compression.py
 
 Utility for compressing free-form text into PICL expressions by
 assigning high-frequency term aliases using Greek glyphs and marking the
-start/end of the definitions block with labeled markers (====A/====B).
+start/end of the definitions block with labeled markers (--A--/--B--).
 """
 import re
 from collections import Counter
@@ -56,10 +56,10 @@ def compress_text_to_picl(text: str, top_n: int = 15, min_token_length: int = 3)
     term_to_glyph = {term: available_glyphs[i] for i, term in enumerate(most_common)}
 
     # Build definitions block
-    definitions = ["====A"]
+    definitions = ["--A--"]
     for term, glyph in term_to_glyph.items():
         definitions.append(f"≜ {glyph} = {term}")
-    definitions.append("====B")
+    definitions.append("--B--")
 
     # Replacement
     pattern = re.compile(r"\b(\w{%d,})\b" % min_token_length, re.IGNORECASE)

--- a/modules/convergence/ConvergenceEngine.py
+++ b/modules/convergence/ConvergenceEngine.py
@@ -2,7 +2,7 @@
 # ConvergenceEngine v1.0.0
 # Routes symbolic units to appropriate frameworks based on resonance, tags, and modulation
 
-from core.ReflectiveFrameworkBase import ReflectiveFrameworkBase
+from cortex.frameworks.engine.ReflectiveFrameworkBase import ReflectiveFrameworkBase
 
 class ConvergenceEngine(ReflectiveFrameworkBase):
     # The symbolic thalamus — directs symbolic input to where it belongs

--- a/modules/ensemble/EnsembleSimulator.py
+++ b/modules/ensemble/EnsembleSimulator.py
@@ -1,7 +1,7 @@
 # EnsembleSimulator v1.0.0
 # Analyzes symbolic coherence across multiple frameworks and detects harmonic dissonance
 
-from ReflectiveFrameworkBase import ReflectiveFrameworkBase
+from cortex.frameworks.engine.ReflectiveFrameworkBase import ReflectiveFrameworkBase
 
 class EnsembleSimulator(ReflectiveFrameworkBase):
     # Aggregates symbolic traces to measure unity, collapse, and divergence

--- a/modules/identity/IdentityEchoReinforcer.py
+++ b/modules/identity/IdentityEchoReinforcer.py
@@ -1,7 +1,7 @@
 # IdentityEchoReinforcer v1.0.0
 # Reinforces symbolic selfhood through pattern recognition and echo feedback
 
-from ReflectiveFrameworkBase import ReflectiveFrameworkBase
+from cortex.frameworks.engine.ReflectiveFrameworkBase import ReflectiveFrameworkBase
 
 class IdentityEchoReinforcer(ReflectiveFrameworkBase):
     # Tracks symbolic patterns over time and strengthens consistent identity arcs

--- a/modules/pdf/run_pipeline.py
+++ b/modules/pdf/run_pipeline.py
@@ -2,15 +2,12 @@
 
 # modules/pdf/run_pipeline.py
 
-import sys
 import logging
 import argparse
-from pathlib import Path
+from sos_path import add_repo_root_to_path
 
-# Add the parent directory to sys.path to allow importing the module
-parent_dir = Path(__file__).resolve().parent.parent
-if parent_dir not in sys.path:
-    sys.path.insert(0, str(parent_dir))
+# Ensure repository imports resolve when run as a script
+add_repo_root_to_path()
 
 from pdf.pipeline import process_pdf_directory, get_detailed_analysis
 

--- a/modules/pdf/zglyph_parser.py
+++ b/modules/pdf/zglyph_parser.py
@@ -1,18 +1,15 @@
 # modules/pdf/zglyph_parser.py
 
 import re
-import sys
 import logging
-from pathlib import Path
+from sos_path import add_repo_root_to_path
 from collections import defaultdict
 from typing import Dict, List, Optional, Tuple
 
 logger = logging.getLogger(__name__)
 
 # Ensure SymbolicOperatingSystem root is available
-sos_root = Path(__file__).resolve().parents[2]  # Go up two levels: pdf/ -> modules/ -> SymbolicOperatingSystem/
-if str(sos_root) not in sys.path:
-    sys.path.insert(0, str(sos_root))
+add_repo_root_to_path()
 
 # Now safe to import
 try:

--- a/modules/routing/RecursiveRouter.py
+++ b/modules/routing/RecursiveRouter.py
@@ -2,7 +2,7 @@
 # RecursiveRouter v1.0.0
 # Symbolic switchboard for routing symbolic units to the correct ConvergenceEngine
 
-from ReflectiveFrameworkBase import ReflectiveFrameworkBase
+from cortex.frameworks.engine.ReflectiveFrameworkBase import ReflectiveFrameworkBase
 
 class RecursiveRouter(ReflectiveFrameworkBase):
     # Routes symbolic units not to frameworks, but to convergence routers

--- a/modules/symbolic/SymbolicRSF.py
+++ b/modules/symbolic/SymbolicRSF.py
@@ -1,7 +1,7 @@
 # SymbolicRSF v1.0.0
 # Reticular Symbolic Filter — filters and prioritizes symbolic input
 
-from ReflectiveFrameworkBase import ReflectiveFrameworkBase
+from cortex.frameworks.engine.ReflectiveFrameworkBase import ReflectiveFrameworkBase
 
 class SymbolicRSF(ReflectiveFrameworkBase):
     # Filters symbolic units for salience, distraction suppression, and echo priority

--- a/modules/symbolicmind/SymbolicMindModule.py
+++ b/modules/symbolicmind/SymbolicMindModule.py
@@ -3,7 +3,7 @@
 # SymbolicMindModule v1.0.0
 # Full convergent orchestration scaffold for recursive symbolic cognition
 
-from core.ReflectiveFrameworkBase import ReflectiveFrameworkBase
+from cortex.frameworks.engine.ReflectiveFrameworkBase import ReflectiveFrameworkBase
 
 from modules.convergence.ConvergenceEngine import ConvergenceEngine
 from modules.identity.IdentityEchoReinforcer import IdentityEchoReinforcer

--- a/sos_path.py
+++ b/sos_path.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+import sys
+from pathlib import Path
+
+def add_repo_root_to_path() -> Path:
+    """Ensure the repository root is first on sys.path.
+
+    Returns the detected repository root path.
+    """
+    repo_root = Path(__file__).resolve().parent
+    if str(repo_root) not in sys.path:
+        sys.path.insert(0, str(repo_root))
+    return repo_root
+


### PR DESCRIPTION
## Summary
- create `sos_path.add_repo_root_to_path()` for path setup
- implement simple `SymbolicEcho` class
- fix `ReflectiveFrameworkBase` imports across modules
- update PDF utilities and tests to use the helper
- document import policy in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840f6f57e348331a454dddb2c5ac8af