### PR TITLE
Update html2struct to spider related pages

### DIFF
--- a/cortex/scripts/tests/test_html2struct.py
+++ b/cortex/scripts/tests/test_html2struct.py
@@ -1,0 +1,17 @@
+import importlib.util
+from pathlib import Path
+
+root = Path(__file__).resolve().parents[3]
+script = root / "local/bin/html2struct.py"
+spec = importlib.util.spec_from_file_location("html2struct", script)
+html2struct = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(html2struct)
+
+
+def test_process_html_file_no_links():
+    result = html2struct.process_html_file("rocq/index.html")
+    assert "links" not in result
+    assert "link_categories" not in result
+    assert "related" not in result
+    assert result["title"]
+


### PR DESCRIPTION
## Summary
- change `html2struct.py` so `--spider-links` crawls linked pages instead of embedding link data
- remove link/category fields from the output
- add category-based filtering of linked pages
- add tests for the new behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68410a65d36883319c395865e1d021b0