### PR TITLE
Improve html2struct filtering

### DIFF
--- a/cortex/scripts/tests/test_html2struct.py
+++ b/cortex/scripts/tests/test_html2struct.py
@@ -15,3 +15,11 @@ def test_process_html_file_no_links():
     assert "related" not in result
     assert result["title"]
 
+
+def test_should_include_page_filters():
+    org_cats = ['Category:Scientific organizations based in France']
+    id_cats = ['Category:OCLC (identifier)']
+    assert not html2struct.should_include_page(org_cats, title='CNRS')
+    assert not html2struct.should_include_page(id_cats, title='OCLC (identifier)')
+    assert not html2struct.should_include_page([], title='Main Page')
+    assert html2struct.should_include_page(['Category:Logic'], title='Logician')


### PR DESCRIPTION
## Summary
- fix classification logic when batch fetching categories
- exclude pages with identifier suffix or 'Main Page'
- relax meta exclusion and pass title for additional checks
- map API redirects and normalized titles back to the provided titles
- add tests for filtering logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68425b0a6f5c8331be70d4b257fb4342