### PR TITLE
Improve html2struct second‑pass filtering

### DIFF
--- a/cortex/scripts/tests/test_html2struct.py
+++ b/cortex/scripts/tests/test_html2struct.py
@@ -15,3 +15,19 @@ def test_process_html_file_no_links():
     assert "related" not in result
     assert result["title"]
 
+
+def test_should_include_page_filters():
+    org_cats = ['Category:Scientific organizations based in France']
+    id_cats = ['Category:OCLC (identifier)']
+    assert not html2struct.should_include_page(org_cats, title='CNRS')
+    assert not html2struct.should_include_page(id_cats, title='OCLC (identifier)')
+    assert not html2struct.should_include_page([], title='Main Page')
+    assert html2struct.should_include_page(['Category:Logic'], title='Logician')
+    assert html2struct.should_include_page([], title='Random Page')
+
+
+def test_extract_categories_from_html():
+    html_path = Path('stimuli/Mathematics.html')
+    html = html_path.read_text()
+    cats = html2struct.extract_categories_from_html(html)
+    assert 'Mathematics' in cats


### PR DESCRIPTION
## Summary
- resolve merge conflicts and bring in upstream changes
- add `extract_categories_from_html` for second-pass checks
- filter spidered pages after fetching their HTML
- expand html2struct unit tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68425b0a6f5c8331be70d4b257fb4342